### PR TITLE
Added postprocessor to allow embedding Java in C# comments

### DIFF
--- a/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
+++ b/CSharpTranslator/src/CS2JTranslator/CS2JMain/CS2JMain.cs
@@ -709,7 +709,7 @@ namespace Twiglet.CS2J.Translator
                     {
                        if (cfg.DebugLevel >= 1) Console.Out.WriteLine("Writing out {0}", javaFName);
                        StreamWriter javaW = new StreamWriter(javaFName);
-                       javaW.Write(outputMaker.compilation_unit().ToString());
+                       javaW.Write(outputMaker.compilation_unit().ToString().Replace("//CS2J:Java code:", ""));
                        javaW.Close();
                     }
                     else


### PR DESCRIPTION
This is a very simple workaround to give us the ability to directly add small amounts of Java code when translation fails, like we have for C# code.

eg:

<pre>//CS2J:Java code:@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
//CS2J:Java code:@java.lang.annotation.Target(java.lang.annotation.ElementType.FIELD)</pre>

"translates" as: 
<pre>@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
@java.lang.annotation.Target(java.lang.annotation.ElementType.FIELD)
</pre>


Testing: I'm using this to make annotations work for API integration, and it's generating the results I expect.
